### PR TITLE
replace set-output => GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/checks-lights-aws.yml
+++ b/.github/workflows/checks-lights-aws.yml
@@ -39,7 +39,7 @@ jobs:
             report="${report//'%'/'%25'}"
             report="${report//$'\n'/'%0A'}"
             report="${report//$'\r'/'%0D'}"
-            echo "::set-output name=report::$report"
+            echo "report=$report" >> $GITHUB_OUTPUT
           fi
       - name: Send Notification
         if: ${{ steps.lights.outputs.report }}

--- a/.github/workflows/cml-1075.yml
+++ b/.github/workflows/cml-1075.yml
@@ -35,7 +35,7 @@ jobs:
           npx serverless info
           url=$(npx serverless info | awk 'match($0, "endpoint: "){ print substr($0, RSTART + 10)}')
           echo "$url"
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         with:
           name: state

--- a/.github/workflows/cml-1166.yml
+++ b/.github/workflows/cml-1166.yml
@@ -31,7 +31,7 @@ jobs:
           npx serverless info
           url=$(npx serverless info | awk 'match($0, "endpoint: "){ print substr($0, RSTART + 10)}')
           echo "$url"
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         with:
           name: state

--- a/includes/aws/self-host-publish-setup.yml
+++ b/includes/aws/self-host-publish-setup.yml
@@ -18,7 +18,7 @@
           npx serverless info
           url=$(npx serverless info | awk 'match($0, "endpoint: "){ print substr($0, RSTART + 10)}')
           echo "$url"
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         with:
           name: state

--- a/workflows/checks-lights-aws.yml
+++ b/workflows/checks-lights-aws.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::342840881361:role/SandboxUser
-          aws-region: us-east-1 
+          aws-region: us-east-1
       - name: Check the lights
         id: lights
         run: |
@@ -38,7 +38,7 @@ jobs:
             report="${report//'%'/'%25'}"
             report="${report//$'\n'/'%0A'}"
             report="${report//$'\r'/'%0D'}"
-            echo "::set-output name=report::$report"
+            echo "report=$report" >> $GITHUB_OUTPUT
           fi
       - name: Send Notification
         if: ${{ steps.lights.outputs.report }}

--- a/workflows/cml-1075.yml
+++ b/workflows/cml-1075.yml
@@ -34,7 +34,7 @@ jobs:
           npx serverless info
           url=$(npx serverless info | awk 'match($0, "endpoint: "){ print substr($0, RSTART + 10)}')
           echo "$url"
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         with:
           name: state


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands
